### PR TITLE
Fix compilation in the non-mutable case

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(unconditional_recursion)]
 
-use core::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+use core::ops::{Deref, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 use slices::{
     SliceByValue, SliceByValueGet, SliceByValueRange,
     /*SliceByValueRangeMut, */SliceByValueRepl, SliceByValueSet,
@@ -20,69 +20,69 @@ impl<T: ?Sized + ImplBoundPriv> ImplBound for T {}
 pub struct Ref<'a, T: ?Sized>(&'a T);
 impl<T: ?Sized> ImplBoundPriv for Ref<'_, T> {}
 
-impl<T> SliceByValue for [T] {
-    type Value = T;
+impl<U: Clone, T: Deref<Target=[U]>> SliceByValue for T {
+    type Value = U;
     #[inline]
     fn len(&self) -> usize {
-        <[T]>::len(self)
+        (**self).len()
     }
 }
 
 // --- Implementations for standard slices [T] and usize index ---
-impl<T: Clone> SliceByValueGet for [T] {
+impl<U: Clone, T: AsRef<[U]>> SliceByValueGet for T where T: SliceByValue<Value=U> {
     #[inline]
     fn get_value(&self, index: usize) -> Option<Self::Value> {
         // slice.get returns Option<&T>, .copied() converts to Option<T>
-        (*self).get(index).cloned()
+        self.as_ref().get(index).cloned()
     }
 
     #[inline]
     fn index_value(&self, index: usize) -> Self::Value {
         // Standard indexing panics on out-of-bounds.
         // It returns &T, which we copy to return T.
-        self[index].clone()
+        self.as_ref()[index].clone()
     }
 
     #[inline]
     unsafe fn get_value_unchecked(&self, index: usize) -> Self::Value {
         // Safety: The caller must ensure that `*self` (the index) is in bounds.
         // slice.get_unchecked returns &T, which we dereference and copy.
-        unsafe { (*self).get_unchecked(index).clone() }
+        unsafe { self.as_ref().get_unchecked(index).clone() }
     }
 }
 
-impl<T: Clone> SliceByValueSet for [T] {
+impl<U: Clone, T: AsMut<[U]>> SliceByValueSet for T where T: SliceByValue<Value=U> {
     #[inline]
     fn set_value(&mut self, index: usize, value: Self::Value) {
         // Standard indexing panics on out-of-bounds.
-        self[index] = value;
+        self.as_mut()[index] = value;
     }
 
     #[inline]
     unsafe fn set_value_unchecked(&mut self, index: usize, value: Self::Value) {
         // Safety: The caller must ensure that `*self` (the index) is in bounds.
         unsafe {
-            let elem = self.get_unchecked_mut(index);
+            let elem = self.as_mut().get_unchecked_mut(index);
             *elem = value;
         }
     }
 }
 
-impl<T: Clone> SliceByValueRepl for [T] {
+impl<U: Clone, T: AsMut<[U]>> SliceByValueRepl for T where T: SliceByValue<Value=U> {
     #[inline]
     fn replace_value(&mut self, index: usize, value: Self::Value) -> Self::Value {
         // Standard indexing panics on out-of-bounds.
         // We get a mutable reference `&mut T`.
         // mem::replace swaps the value at the location with the new `value`
         // and returns the old value.
-        core::mem::replace(&mut self[index], value)
+        core::mem::replace(&mut self.as_mut()[index], value)
     }
 
     #[inline]
     unsafe fn replace_value_unchecked(&mut self, index: usize, value: Self::Value) -> Self::Value {
         // Safety: The caller must ensure that `*self` (the index) is in bounds.
         unsafe {
-            let elem = self.get_unchecked_mut(index);
+            let elem = self.as_mut().get_unchecked_mut(index);
             core::mem::replace(elem, value)
         }
     }
@@ -90,11 +90,10 @@ impl<T: Clone> SliceByValueRepl for [T] {
 
 macro_rules! impl_range_slices {
     ($range:ty) => {
-        impl<'a, T: Clone> SliceByValueRange<'a, $range> for &'a [T] {
-
+        impl<'a, U: Clone> SliceByValueRange<'a, $range> for &'a [U] where &'a [U]: SliceByValue<Value=U> {
             #[inline]
             fn get_range(&self, index: $range) -> Option<Self> {
-                (*self).get(index)
+                self.get(index)
             }
 
             #[inline]
@@ -104,29 +103,10 @@ macro_rules! impl_range_slices {
 
             #[inline]
             unsafe fn get_range_unchecked(&self, index: $range) -> Self {
-                unsafe { (*self).get_unchecked(index) }
+                unsafe { self.get_unchecked(index) }
             }
         }
-
-        /*
-        impl<T: Clone> SliceByValueRangeMut<$range> for &mut [T] {
-            #[inline]
-            fn get_range_mut(&mut self, index: $range) -> Option<Self> {
-                (*self).get_mut(index)
-            }
-
-            #[inline]
-            fn index_range_mut(&mut self, index: $range) -> Self {
-                &mut self[index]
-            }
-
-            #[inline]
-            unsafe fn get_range_unchecked_mut(&mut self, index: $range) -> Self {
-                unsafe { (*self).get_unchecked_mut(index) }
-            }
-        }
-        */
-    };
+    }
 }
 
 impl_range_slices!(RangeFull);
@@ -136,297 +116,3 @@ impl_range_slices!(Range<usize>);
 impl_range_slices!(RangeInclusive<usize>);
 impl_range_slices!(RangeToInclusive<usize>);
 
-impl<T, const N: usize> SliceByValue for [T; N] {
-    type Value = T;
-    #[inline(always)]
-    fn len(&self) -> usize {
-        N
-    }
-}
-
-impl<T: Clone, const N: usize> SliceByValueGet for [T; N] {
-    #[inline]
-    fn get_value(&self, index: usize) -> Option<Self::Value> {
-        // slice.get returns Option<&T>, .copied() converts to Option<T>
-        (*self).get(index).cloned()
-    }
-
-    #[inline]
-    fn index_value(&self, index: usize) -> Self::Value {
-        // Standard indexing panics on out-of-bounds.
-        // It returns &T, which we copy to return T.
-        self[index].clone()
-    }
-
-    #[inline]
-    unsafe fn get_value_unchecked(&self, index: usize) -> Self::Value {
-        // Safety: The caller must ensure that `*self` (the index) is in bounds.
-        // slice.get_unchecked returns &T, which we dereference and copy.
-        unsafe { (*self).get_unchecked(index).clone() }
-    }
-}
-
-impl<T: Clone, const N: usize> SliceByValueSet for [T; N] {
-    #[inline]
-    fn set_value(&mut self, index: usize, value: Self::Value) {
-        // Standard indexing panics on out-of-bounds.
-        self[index] = value;
-    }
-
-    #[inline]
-    unsafe fn set_value_unchecked(&mut self, index: usize, value: Self::Value) {
-        // Safety: The caller must ensure that `*self` (the index) is in bounds.
-        unsafe {
-            let elem = self.get_unchecked_mut(index);
-            *elem = value;
-        }
-    }
-}
-
-impl<T: Clone, const N: usize> SliceByValueRepl for [T; N] {
-    #[inline]
-    fn replace_value(&mut self, index: usize, value: Self::Value) -> Self::Value {
-        // Standard indexing panics on out-of-bounds.
-        // We get a mutable reference `&mut T`.
-        // mem::replace swaps the value at the location with the new `value`
-        // and returns the old value.
-        core::mem::replace(&mut self[index], value)
-    }
-
-    #[inline]
-    unsafe fn replace_value_unchecked(&mut self, index: usize, value: Self::Value) -> Self::Value {
-        // Safety: The caller must ensure that `*self` (the index) is in bounds.
-        unsafe {
-            let elem = self.get_unchecked_mut(index);
-            core::mem::replace(elem, value)
-        }
-    }
-}
-
-/*
-macro_rules! impl_range_arrays {
-    ($range:ty) => {
-        impl<T: Clone, const N: usize> SliceByValueRange<$range> for [T; N] {
-            #[inline]
-            fn get_range(&self, index: $range) -> Option<Self> {
-                (*self).get(index)
-            }
-
-            #[inline]
-            fn index_range(&self, index: $range) -> Self {
-                &self[index]
-            }
-
-            #[inline]
-            unsafe fn get_range_unchecked(&self, index: $range) -> Self {
-                unsafe { (*self).get_unchecked(index) }
-            }
-        }
-    };
-}
-
-impl_range_arrays!(RangeFull);
-impl_range_arrays!(RangeFrom<usize>);
-impl_range_arrays!(RangeTo<usize>);
-impl_range_arrays!(Range<usize>);
-impl_range_arrays!(RangeInclusive<usize>);
-impl_range_arrays!(RangeToInclusive<usize>);
-*/
-
-#[cfg(feature = "alloc")]
-mod alloc_impls {
-    use super::*;
-    extern crate alloc;
-    use alloc::boxed::Box;
-    use alloc::vec::Vec;
-
-    impl<S: SliceByValue + ?Sized> SliceByValue for Box<S> {
-        type Value = S::Value;
-        #[inline]
-        fn len(&self) -> usize {
-            (**self).len()
-        }
-    }
-
-    impl<S: SliceByValueGet + ?Sized> SliceByValueGet for Box<S> {
-        fn get_value(&self, index: usize) -> Option<Self::Value> {
-            (**self).get_value(index)
-        }
-        fn index_value(&self, index: usize) -> Self::Value {
-            (**self).index_value(index)
-        }
-        unsafe fn get_value_unchecked(&self, index: usize) -> Self::Value {
-            unsafe { (**self).get_value_unchecked(index) }
-        }
-    }
-
-    impl<S: SliceByValueRepl + ?Sized> SliceByValueRepl for Box<S> {
-        fn replace_value(&mut self, index: usize, value: Self::Value) -> Self::Value {
-            (**self).replace_value(index, value)
-        }
-        unsafe fn replace_value_unchecked(
-            &mut self,
-            index: usize,
-            value: Self::Value,
-        ) -> Self::Value {
-            unsafe { (**self).replace_value_unchecked(index, value) }
-        }
-    }
-
-    impl<S: SliceByValueSet + ?Sized> SliceByValueSet for Box<S> {
-        fn set_value(&mut self, index: usize, value: Self::Value) {
-            (**self).set_value(index, value)
-        }
-        unsafe fn set_value_unchecked(&mut self, index: usize, value: Self::Value) {
-            unsafe { (**self).set_value_unchecked(index, value) }
-        }
-    }
-
-    impl<T> SliceByValue for Vec<T> {
-        type Value = T;
-        #[inline]
-        fn len(&self) -> usize {
-            <[T]>::len(self)
-        }
-    }
-
-    impl<T: Clone> SliceByValueGet for Vec<T> {
-        #[inline]
-        fn get_value(&self, index: usize) -> Option<Self::Value> {
-            // slice.get returns Option<&T>, .copied() converts to Option<T>
-            (*self).get(index).cloned()
-        }
-
-        #[inline]
-        fn index_value(&self, index: usize) -> Self::Value {
-            // Standard indexing panics on out-of-bounds.
-            // It returns &T, which we copy to return T.
-            self[index].clone()
-        }
-
-        #[inline]
-        unsafe fn get_value_unchecked(&self, index: usize) -> Self::Value {
-            // Safety: The caller must ensure that `*self` (the index) is in bounds.
-            // slice.get_unchecked returns &T, which we dereference and copy.
-            unsafe { (*self).get_unchecked(index).clone() }
-        }
-    }
-
-    impl<T: Clone> SliceByValueRepl for Vec<T> {
-        #[inline]
-        fn replace_value(&mut self, index: usize, value: Self::Value) -> Self::Value {
-            // Standard indexing panics on out-of-bounds.
-            // We get a mutable reference `&mut T`.
-            // mem::replace swaps the value at the location with the new `value`
-            // and returns the old value.
-            core::mem::replace(&mut self[index], value)
-        }
-
-        #[inline]
-        unsafe fn replace_value_unchecked(
-            &mut self,
-            index: usize,
-            value: Self::Value,
-        ) -> Self::Value {
-            // Safety: The caller must ensure that `*self` (the index) is in bounds.
-            unsafe {
-                let elem = self.get_unchecked_mut(index);
-                core::mem::replace(elem, value)
-            }
-        }
-    }
-
-    impl<T: Clone> SliceByValueSet for Vec<T> {
-        #[inline]
-        fn set_value(&mut self, index: usize, value: Self::Value) {
-            // Standard indexing panics on out-of-bounds
-            self[index] = value;
-        }
-
-        #[inline]
-        unsafe fn set_value_unchecked(&mut self, index: usize, value: Self::Value) {
-            // Safety: The caller must ensure that `*self` (the index) is in bounds.
-            unsafe {
-                let elem = self.get_unchecked_mut(index);
-                *elem = value;
-            }
-        }
-    }
-
-    /*
-    macro_rules! impl_range_vecs {
-        ($range:ty) => {
-            impl<T: Clone> SliceByValueRange<$range> for Vec<T> {
-                #[inline]
-                fn get_range(&self, index: $range) -> Option<Self> {
-                    // slice.get returns Option<&T>, .copied() converts to Option<T>
-                    (*self).get(index)
-                }
-
-                #[inline]
-                fn index_range(&self, index: $range) -> Self {
-                    &self[index]
-                }
-
-                #[inline]
-                unsafe fn get_range_unchecked(&self, index: $range) -> Self {
-                    unsafe { (*self).get_unchecked(index) }
-                }
-            }
-        };
-    }
-
-    impl_range_vecs!(RangeFull);
-    impl_range_vecs!(RangeFrom<usize>);
-    impl_range_vecs!(RangeTo<usize>);
-    impl_range_vecs!(Range<usize>);
-    impl_range_vecs!(RangeInclusive<usize>);
-    impl_range_vecs!(RangeToInclusive<usize>);
-    */
-}
-
-#[cfg(feature = "std")]
-mod std_impls {
-    use super::*;
-    use std::{rc::Rc, sync::Arc};
-
-    impl<S: SliceByValue + ?Sized> SliceByValue for Arc<S> {
-        type Value = S::Value;
-        #[inline]
-        fn len(&self) -> usize {
-            (**self).len()
-        }
-    }
-
-    impl<S: SliceByValueGet + ?Sized> SliceByValueGet for Arc<S> {
-        fn get_value(&self, index: usize) -> Option<Self::Value> {
-            (**self).get_value(index)
-        }
-        fn index_value(&self, index: usize) -> Self::Value {
-            (**self).index_value(index)
-        }
-        unsafe fn get_value_unchecked(&self, index: usize) -> Self::Value {
-            (**self).get_value_unchecked(index)
-        }
-    }
-
-    impl<S: SliceByValue + ?Sized> SliceByValue for Rc<S> {
-        type Value = S::Value;
-        #[inline]
-        fn len(&self) -> usize {
-            (**self).len()
-        }
-    }
-
-    impl<S: SliceByValueGet + ?Sized> SliceByValueGet for Rc<S> {
-        fn get_value(&self, index: usize) -> Option<Self::Value> {
-            (**self).get_value(index)
-        }
-        fn index_value(&self, index: usize) -> Self::Value {
-            (**self).index_value(index)
-        }
-        unsafe fn get_value_unchecked(&self, index: usize) -> Self::Value {
-            (**self).get_value_unchecked(index)
-        }
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@
 
 use core::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 use slices::{
-    SliceByValue, SliceByValueGat, SliceByValueGatMut, SliceByValueGet, SliceByValueRange,
-    SliceByValueRangeMut, SliceByValueRepl, SliceByValueSet, Subslice, SubsliceMut,
+    SliceByValue, SliceByValueGet, SliceByValueRange,
+    /*SliceByValueRangeMut, */SliceByValueRepl, SliceByValueSet,
 };
 
 pub mod iter;
@@ -88,49 +88,44 @@ impl<T: Clone> SliceByValueRepl for [T] {
     }
 }
 
-impl<'a, T: Clone> SliceByValueGat<'a> for [T] {
-    type Subslice = &'a [T];
-}
-
-impl<'a, T: Clone> SliceByValueGatMut<'a> for [T] {
-    type Subslice = &'a mut [T];
-}
-
 macro_rules! impl_range_slices {
     ($range:ty) => {
-        impl<T: Clone> SliceByValueRange<$range> for [T] {
+        impl<'a, T: Clone> SliceByValueRange<'a, $range> for &'a [T] {
+
             #[inline]
-            fn get_range(&self, index: $range) -> Option<Subslice<'_, Self>> {
+            fn get_range(&self, index: $range) -> Option<Self> {
                 (*self).get(index)
             }
 
             #[inline]
-            fn index_range(&self, index: $range) -> Subslice<'_, Self> {
+            fn index_range(&self, index: $range) -> Self {
                 &self[index]
             }
 
             #[inline]
-            unsafe fn get_range_unchecked(&self, index: $range) -> Subslice<'_, Self> {
+            unsafe fn get_range_unchecked(&self, index: $range) -> Self {
                 unsafe { (*self).get_unchecked(index) }
             }
         }
 
-        impl<T: Clone> SliceByValueRangeMut<$range> for [T] {
+        /*
+        impl<T: Clone> SliceByValueRangeMut<$range> for &mut [T] {
             #[inline]
-            fn get_range_mut(&mut self, index: $range) -> Option<SubsliceMut<'_, Self>> {
+            fn get_range_mut(&mut self, index: $range) -> Option<Self> {
                 (*self).get_mut(index)
             }
 
             #[inline]
-            fn index_range_mut(&mut self, index: $range) -> SubsliceMut<'_, Self> {
+            fn index_range_mut(&mut self, index: $range) -> Self {
                 &mut self[index]
             }
 
             #[inline]
-            unsafe fn get_range_unchecked_mut(&mut self, index: $range) -> SubsliceMut<'_, Self> {
+            unsafe fn get_range_unchecked_mut(&mut self, index: $range) -> Self {
                 unsafe { (*self).get_unchecked_mut(index) }
             }
         }
+        */
     };
 }
 
@@ -208,25 +203,22 @@ impl<T: Clone, const N: usize> SliceByValueRepl for [T; N] {
     }
 }
 
-impl<'a, T: Clone, const N: usize> SliceByValueGat<'a> for [T; N] {
-    type Subslice = &'a [T];
-}
-
+/*
 macro_rules! impl_range_arrays {
     ($range:ty) => {
         impl<T: Clone, const N: usize> SliceByValueRange<$range> for [T; N] {
             #[inline]
-            fn get_range(&self, index: $range) -> Option<Subslice<'_, Self>> {
+            fn get_range(&self, index: $range) -> Option<Self> {
                 (*self).get(index)
             }
 
             #[inline]
-            fn index_range(&self, index: $range) -> Subslice<'_, Self> {
+            fn index_range(&self, index: $range) -> Self {
                 &self[index]
             }
 
             #[inline]
-            unsafe fn get_range_unchecked(&self, index: $range) -> Subslice<'_, Self> {
+            unsafe fn get_range_unchecked(&self, index: $range) -> Self {
                 unsafe { (*self).get_unchecked(index) }
             }
         }
@@ -239,6 +231,7 @@ impl_range_arrays!(RangeTo<usize>);
 impl_range_arrays!(Range<usize>);
 impl_range_arrays!(RangeInclusive<usize>);
 impl_range_arrays!(RangeToInclusive<usize>);
+*/
 
 #[cfg(feature = "alloc")]
 mod alloc_impls {
@@ -360,26 +353,23 @@ mod alloc_impls {
         }
     }
 
-    impl<'a, T: Clone> SliceByValueGat<'a> for Vec<T> {
-        type Subslice = &'a [T];
-    }
-
+    /*
     macro_rules! impl_range_vecs {
         ($range:ty) => {
             impl<T: Clone> SliceByValueRange<$range> for Vec<T> {
                 #[inline]
-                fn get_range(&self, index: $range) -> Option<Subslice<'_, Self>> {
+                fn get_range(&self, index: $range) -> Option<Self> {
                     // slice.get returns Option<&T>, .copied() converts to Option<T>
                     (*self).get(index)
                 }
 
                 #[inline]
-                fn index_range(&self, index: $range) -> Subslice<'_, Self> {
+                fn index_range(&self, index: $range) -> Self {
                     &self[index]
                 }
 
                 #[inline]
-                unsafe fn get_range_unchecked(&self, index: $range) -> Subslice<'_, Self> {
+                unsafe fn get_range_unchecked(&self, index: $range) -> Self {
                     unsafe { (*self).get_unchecked(index) }
                 }
             }
@@ -392,6 +382,7 @@ mod alloc_impls {
     impl_range_vecs!(Range<usize>);
     impl_range_vecs!(RangeInclusive<usize>);
     impl_range_vecs!(RangeToInclusive<usize>);
+    */
 }
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 use core::ops::{Deref, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 use slices::{
     SliceByValue, SliceByValueGet, SliceByValueRange,
-    /*SliceByValueRangeMut, */SliceByValueRepl, SliceByValueSet,
+    SliceByValueRangeMut, SliceByValueRepl, SliceByValueSet,
 };
 
 pub mod iter;
@@ -104,6 +104,23 @@ macro_rules! impl_range_slices {
             #[inline]
             unsafe fn get_range_unchecked(&self, index: $range) -> Self {
                 unsafe { self.get_unchecked(index) }
+            }
+        }
+
+        impl<'a, U: Clone> SliceByValueRangeMut<'a, $range> for &'a mut [U] where &'a mut [U]: SliceByValue<Value=U> {
+            #[inline]
+            fn get_range_mut(&'a mut self, index: $range) -> Option<Self> {
+                self.get_mut(index)
+            }
+
+            #[inline]
+            fn index_range_mut(&'a mut self, index: $range) -> Self {
+                &mut self[index]
+            }
+
+            #[inline]
+            unsafe fn get_range_unchecked_mut(&'a mut self, index: $range) -> Self {
+                unsafe { self.get_unchecked_mut(index) }
             }
         }
     }

--- a/src/slices/mod.rs
+++ b/src/slices/mod.rs
@@ -62,22 +62,6 @@ pub trait SliceByValue {
     }
 }
 
-impl<S: SliceByValue + ?Sized> SliceByValue for &S {
-    type Value = S::Value;
-    #[inline]
-    fn len(&self) -> usize {
-        (**self).len()
-    }
-}
-
-impl<S: SliceByValue + ?Sized> SliceByValue for &mut S {
-    type Value = S::Value;
-    #[inline]
-    fn len(&self) -> usize {
-        (**self).len()
-    }
-}
-
 /// Read-only slice-by-value trait.
 pub trait SliceByValueGet: SliceByValue {
     /// See [the `Index` implementation for slices](slice#impl-Index%3CI%3E-for-%5BT%5D).
@@ -90,30 +74,6 @@ pub trait SliceByValueGet: SliceByValue {
 
     /// See [`slice::get`].
     fn get_value(&self, index: usize) -> Option<Self::Value>;
-}
-
-impl<S: SliceByValueGet + ?Sized> SliceByValueGet for &S {
-    fn get_value(&self, index: usize) -> Option<Self::Value> {
-        (**self).get_value(index)
-    }
-    fn index_value(&self, index: usize) -> Self::Value {
-        (**self).index_value(index)
-    }
-    unsafe fn get_value_unchecked(&self, index: usize) -> Self::Value {
-        unsafe { (**self).get_value_unchecked(index) }
-    }
-}
-
-impl<S: SliceByValueGet + ?Sized> SliceByValueGet for &mut S {
-    fn get_value(&self, index: usize) -> Option<Self::Value> {
-        (**self).get_value(index)
-    }
-    fn index_value(&self, index: usize) -> Self::Value {
-        (**self).index_value(index)
-    }
-    unsafe fn get_value_unchecked(&self, index: usize) -> Self::Value {
-        unsafe { (**self).get_value_unchecked(index) }
-    }
 }
 
 /// Mutable slice-by-value trait, providing setting methods.
@@ -131,15 +91,6 @@ pub trait SliceByValueSet: SliceByValue {
     fn set_value(&mut self, index: usize, value: Self::Value);
 }
 
-impl<S: SliceByValueSet + ?Sized> SliceByValueSet for &mut S {
-    fn set_value(&mut self, index: usize, value: Self::Value) {
-        (**self).set_value(index, value)
-    }
-    unsafe fn set_value_unchecked(&mut self, index: usize, value: Self::Value) {
-        unsafe { (**self).set_value_unchecked(index, value) }
-    }
-}
-
 /// Mutable slice-by-value trait, providing replacement methods.
 ///
 /// If you just need to set a value, use [`SliceByValueSet`] instead.
@@ -153,15 +104,6 @@ pub trait SliceByValueRepl: SliceByValue {
     /// Sets the value at the given index to the given value and
     /// returns the previous value.
     fn replace_value(&mut self, index: usize, value: Self::Value) -> Self::Value;
-}
-
-impl<S: SliceByValueRepl + ?Sized> SliceByValueRepl for &mut S {
-    fn replace_value(&mut self, index: usize, value: Self::Value) -> Self::Value {
-        (**self).replace_value(index, value)
-    }
-    unsafe fn replace_value_unchecked(&mut self, index: usize, value: Self::Value) -> Self::Value {
-        unsafe { (**self).replace_value_unchecked(index, value) }
-    }
 }
 
 pub trait SliceByValueRange<'a, R>: SliceByValue + Sized + 'a {

--- a/src/slices/mod.rs
+++ b/src/slices/mod.rs
@@ -42,6 +42,21 @@
 //! }
 //! ```
 //!
+//! This signature is for a function that takes a mutable value-based slice of `u64`:
+//! ```rust
+//! use value_traits::slices::*;
+//!
+//! fn takes_mut_slice_of_uint64<'a> (slice: &'a mut (impl SliceByValue<Value = u64> + SliceByValueSet + SliceByValueSubsliceMut<'a>)) {
+//!     // We can write values
+//!     slice.set_value(0, 42);
+//!     // We can get a mutable subslice
+//!     let mut s = slice.index_range_mut(0..5);
+//!     // And subslice it again with another range, getting the same type
+//!     let mut t = s.index_range_mut(1..2);
+//!     // let mut z = t.index_range_mut(..); // does not compile (can't mutable borrow twice)
+//! }
+//! ```
+//!
 //!
 
 use core::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
@@ -119,58 +134,19 @@ pub trait SliceByValueRange<'a, R>: SliceByValue + Sized + 'a {
     fn get_range(&self, range: R) -> Option<Self>;
 }
 
-/*
-impl<'a, S: SliceByValueRange<'a, R> + ?Sized + 'a, R> SliceByValueRange<'a, R> for &'a S {
-    fn get_range(&'a self, range: R) -> Option<Self> {
-        (**self).get_range(range).as_ref()
-    }
-    fn index_range(&'a self, range: R) -> Self {
-        &(**self).index_range(range)
-    }
-    unsafe fn get_range_unchecked(&'a self, range: R) -> Self {
-        &(**self).get_range_unchecked(range)
-    }
-}
-impl<'a, S: SliceByValueRange<'a, R> + ?Sized, R> SliceByValueRange<'a, R> for &'a mut S {
-    fn get_range(&self, range: R) -> Option<Self> {
-        (**self).get_range(range).as_mut()
-    }
-    fn index_range(&self, range: R) -> Self {
-        &mut (**self).index_range(range)
-    }
-    unsafe fn get_range_unchecked(&self, range: R) -> Self {
-        &mut (**self).get_range_unchecked(range)
-    }
-}
-*/
-
-
-/*
-pub trait SliceByValueRangeMut<R>: SliceByValue + Sized {
+pub trait SliceByValueRangeMut<'a, R>: SliceByValue + Sized + 'a {
     /// See [the `Index` implementation for slices](slice#impl-Index%3CI%3E-for-%5BT%5D).
-    fn index_range_mut(&mut self, range: R) -> Self;
+    fn index_range_mut(&'a mut self, range: R) -> Self;
 
     /// See [`slice::get_unchecked`].
     ///
     /// For a safe alternative see [`SliceByValue::get_value`].
-    unsafe fn get_range_unchecked_mut(&mut self, range: R) -> Self;
+    unsafe fn get_range_unchecked_mut(&'a mut self, range: R) -> Self;
 
     /// See [`slice::get`].
-    fn get_range_mut(&mut self, range: R) -> Option<Self>;
+    fn get_range_mut(&'a mut self, range: R) -> Option<Self>;
 }
 
-impl<S: SliceByValueRangeMut<R> + ?Sized, R> SliceByValueRangeMut<R> for &mut S {
-    fn get_range_mut(&mut self, range: R) -> Option<Self> {
-        (**self).get_range_mut(range).as_mut()
-    }
-    fn index_range_mut(&mut self, range: R) -> Self {
-        &mut (**self).index_range_mut(range)
-    }
-    unsafe fn get_range_unchecked_mut(&mut self, range: R) -> Self {
-        &mut (**self).get_range_unchecked_mut(range)
-    }
-}
-*/
 
 /// Helper trait for requesting all common range types, and enforce that they all
 /// return the same type of slice.
@@ -195,26 +171,24 @@ where
 {
 }
 
-/*
 /// Mutable version of [`SliceByValueRangeAll`].
-pub trait SliceByValueSubsliceMut<T = usize>:
-    SliceByValueRangeMut<Range<T>>
-    + SliceByValueRangeMut<RangeFrom<T>>
-    + SliceByValueRangeMut<RangeFull>
-    + SliceByValueRangeMut<RangeInclusive<T>>
-    + SliceByValueRangeMut<RangeTo<T>>
-    + SliceByValueRangeMut<RangeToInclusive<T>>
+pub trait SliceByValueSubsliceMut<'a, T = usize>:
+    SliceByValueRangeMut<'a, Range<T>>
+    + SliceByValueRangeMut<'a, RangeFrom<T>>
+    + SliceByValueRangeMut<'a, RangeFull>
+    + SliceByValueRangeMut<'a, RangeInclusive<T>>
+    + SliceByValueRangeMut<'a, RangeTo<T>>
+    + SliceByValueRangeMut<'a, RangeToInclusive<T>>
 {
 }
 
-impl<U, T> SliceByValueSubsliceMut<T> for U
+impl<'a, U, T> SliceByValueSubsliceMut<'a, T> for U
 where
-    U: SliceByValueRangeMut<Range<T>>,
-    U: SliceByValueRangeMut<RangeFrom<T>>,
-    U: SliceByValueRangeMut<RangeFull>,
-    U: SliceByValueRangeMut<RangeInclusive<T>>,
-    U: SliceByValueRangeMut<RangeTo<T>>,
-    U: SliceByValueRangeMut<RangeToInclusive<T>>,
+    U: SliceByValueRangeMut<'a, Range<T>>,
+    U: SliceByValueRangeMut<'a, RangeFrom<T>>,
+    U: SliceByValueRangeMut<'a, RangeFull>,
+    U: SliceByValueRangeMut<'a, RangeInclusive<T>>,
+    U: SliceByValueRangeMut<'a, RangeTo<T>>,
+    U: SliceByValueRangeMut<'a, RangeToInclusive<T>>,
 {
 }
-*/

--- a/tests/test_bounds.rs
+++ b/tests/test_bounds.rs
@@ -1,18 +1,17 @@
 use value_traits::slices::*;
 
-/*
 #[test]
 fn test() {
     let s = vec![1_i32, 2, 3, 4, 5];
-    test_bounds(&s);
+    test_bounds(&s[..]);
 }
 
 // Compile-time check that all ranges can be forced to the same type
-fn test_bounds(s: &impl SliceByValueSubslice) {
+fn test_bounds<'a>(s: impl SliceByValueSubslice<'a>) {
     let mut _r = s.index_range(0..2);
     _r = s.index_range(0..);
     _r = s.index_range(..2);
     _r = s.index_range(..=2);
     _r = s.index_range(0..=2);
     _r = s.index_range(..);
-}*/
+}

--- a/tests/test_bounds.rs
+++ b/tests/test_bounds.rs
@@ -1,5 +1,6 @@
 use value_traits::slices::*;
 
+/*
 #[test]
 fn test() {
     let s = vec![1_i32, 2, 3, 4, 5];
@@ -14,4 +15,4 @@ fn test_bounds(s: &impl SliceByValueSubslice) {
     _r = s.index_range(..=2);
     _r = s.index_range(0..=2);
     _r = s.index_range(..);
-}
+}*/

--- a/tests/test_slices.rs
+++ b/tests/test_slices.rs
@@ -11,46 +11,44 @@ fn test_slices() {
     assert_eq!(test_len(&t), 3);
 
     let t = s.as_mut_slice();
-    assert_eq!(test_range_mut(t), &mut [1, 2]);
+    //assert_eq!(test_range_mut(t), &mut [1, 2]);
 }
 
 fn test_usize(s: impl SliceByValueGet<Value = i32>) -> i32 {
     s.index_value(0_usize)
 }
 
-fn test_range<'a, S>(s: &S) -> &[i32]
+fn test_range<'a, S>(s: &'a S) -> S
 where
-    S: SliceByValueRange<Range<usize>>,
-    S: for<'b> SliceByValueGat<'b, Subslice = &'b [i32]>,
+    S: SliceByValueRange<'a, Range<usize>>,
 {
     let a = s.index_range(0..2);
     let _ = s.index_range(0..3); // it can be borrowed multiple times
     a
 }
 
-fn test_range_mut<'a, S>(s: &mut S) -> &mut [i32]
+/*
+fn test_range_mut<'a, S>(s: &'a mut S) -> &mut [i32]
 where
-    S: SliceByValueRangeMut<Range<usize>> + ?Sized,
-    S: for<'b> SliceByValueGatMut<'b, Subslice = &'b mut [i32]>,
+    S: SliceByValueRangeMut<'a, Range<usize>> + ?Sized,
 {
     let a = s.index_range_mut(0..2);
     // let _ = s.index_range_mut(0..2); // this instead should not compile
     a
 }
+*/
 
-fn test_usize_range<'a, S>(s: &S) -> (i32, &[i32])
+fn test_usize_range<'a, S>(s: &'a S) -> (i32, S)
 where
     S: SliceByValueGet<Value = i32>,
-    S: SliceByValueRange<Range<usize>>,
-    S: for<'b> SliceByValueGat<'b, Subslice = &'b [i32]>,
+    S: SliceByValueRange<'a, Range<usize>>,
 {
     (s.index_value(0_usize), s.index_range(0..2))
 }
 
-fn test_len<'a, S>(s: &S) -> usize
+fn test_len<'a, S>(s: &'a S) -> usize
 where
-    S: SliceByValueRange<Range<usize>>,
-    S: for<'b> SliceByValueGat<'b, Subslice = &'b [i32]>,
+    S: SliceByValueRange<'a, Range<usize>>,
 {
     s.len()
 }

--- a/tests/test_slices.rs
+++ b/tests/test_slices.rs
@@ -10,8 +10,8 @@ fn test_slices() {
     assert_eq!(test_usize_range(&t), (1, [1, 2].as_ref()));
     assert_eq!(test_len(&t), 3);
 
-    let t = s.as_mut_slice();
-    //assert_eq!(test_range_mut(t), &mut [1, 2]);
+    let mut t = s.as_mut_slice();
+    assert_eq!(test_range_mut(&mut t), &mut [1, 2]);
 }
 
 fn test_usize(s: impl SliceByValueGet<Value = i32>) -> i32 {
@@ -27,8 +27,7 @@ where
     a
 }
 
-/*
-fn test_range_mut<'a, S>(s: &'a mut S) -> &mut [i32]
+fn test_range_mut<'a, S>(s: &'a mut S) -> S
 where
     S: SliceByValueRangeMut<'a, Range<usize>> + ?Sized,
 {
@@ -36,7 +35,6 @@ where
     // let _ = s.index_range_mut(0..2); // this instead should not compile
     a
 }
-*/
 
 fn test_usize_range<'a, S>(s: &'a S) -> (i32, S)
 where

--- a/tests/test_vecs.rs
+++ b/tests/test_vecs.rs
@@ -1,7 +1,9 @@
 use value_traits::slices::*;
 
+/*
 #[test]
 fn test_vecs() {
     let s = vec![1_i32, 2, 3, 4, 5];
     assert_eq!(s.index_range(1..).index_range(..3), [2, 3, 4].as_ref());
 }
+*/

--- a/tests/test_vecs.rs
+++ b/tests/test_vecs.rs
@@ -1,9 +1,7 @@
 use value_traits::slices::*;
 
-/*
 #[test]
 fn test_vecs() {
     let s = vec![1_i32, 2, 3, 4, 5];
-    assert_eq!(s.index_range(1..).index_range(..3), [2, 3, 4].as_ref());
+    assert_eq!((&s[..]).index_range(1..).index_range(..3), [2, 3, 4].as_ref());
 }
-*/


### PR DESCRIPTION
This makes the existing examples work with minor changes, at the expanse of not working on "owned" structures anymore, they need to be sliced with an external trait or ad-hoc method before subslicing.

And the problem remains on mutable slices.